### PR TITLE
Maintain release workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,6 +10,8 @@ jobs:
   build-n-publish:
       name: Build and publish to PyPI
       runs-on: ubuntu-latest
+      permissions:
+        contents: write
 
       steps:
         - name: Checkout source
@@ -36,6 +38,7 @@ jobs:
         - name: Publish distribution to PyPI
           uses: pypa/gh-action-pypi-publish@release/v1
           with:
+            skip-existing: true
             password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
             # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
 


### PR DESCRIPTION
Hi Thomas,

This PR updates permission for release workflow and allow to skip if existing same version on pypi.

Thank you,
Ngoan